### PR TITLE
Support TypeScript 6 style config with paths only (no baseUrl)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coten-inc/eslint-plugin-relative-imports-when-same-folder",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "An eslint plugin to convert any absolute import paths to relative ones if files are imported from within the same folder",
   "main": "dist/index.js",
   "scripts": {

--- a/src/no-relative-imports-when-same-folder/createRule.test.js
+++ b/src/no-relative-imports-when-same-folder/createRule.test.js
@@ -77,6 +77,50 @@ describe('createRule', () => {
 		});
 	});
 
+	describe('with TypeScript 6 style config (paths only, no baseUrl)', () => {
+		const tsConfig = {
+			compilerOptions: {
+				paths: {
+					'@library': ['./src/library/index.js'],
+					'@library/*': ['./src/library/*'],
+				},
+			},
+		};
+
+		it('reports an error for an import from the same folder', () => {
+			runRuleForPath({
+				inspectedFilePath:
+					'/Users/spic/dev/some_repo/src/library/components/FormCheckbox/FormCheckbox.tsx',
+				importPath: '@library/components/FormCheckbox/Form.scss',
+				tsConfig,
+			});
+
+			expect(defaultContext.report).toHaveBeenCalledWith({
+				data: {
+					fixedImportPath: './Form.scss',
+				},
+				fix: expect.any(Function),
+				messageId: messageIds.importCanBeRelative,
+				node: {
+					source: {
+						value: '@library/components/FormCheckbox/Form.scss',
+					},
+				},
+			});
+		});
+
+		it('does not report an error for an import from a sibling folder', () => {
+			runRuleForPath({
+				inspectedFilePath:
+					'/Users/spic/dev/some_repo/src/library/components/FormCheckbox/FormCheckbox.tsx',
+				importPath: '@library/components/Form/Form.scss',
+				tsConfig,
+			});
+
+			expect(defaultContext.report).not.toHaveBeenCalled();
+		});
+	});
+
 	describe('for absolute import paths', () => {
 		const tsConfig = {
 			compilerOptions: {

--- a/src/no-relative-imports-when-same-folder/utils/tsConfig/checkIfTsConfigAdaptsModuleResolution.js
+++ b/src/no-relative-imports-when-same-folder/utils/tsConfig/checkIfTsConfigAdaptsModuleResolution.js
@@ -1,5 +1,6 @@
 export default function checkIfTsConfigAdaptsModuleResolution(tsConfig) {
 	const { compilerOptions } = tsConfig;
 
-	return 'baseUrl' in compilerOptions;
+	// TypeScript 6 deprecated `baseUrl`; `paths` alone is now sufficient
+	return 'baseUrl' in compilerOptions || 'paths' in compilerOptions;
 }

--- a/src/no-relative-imports-when-same-folder/utils/tsConfig/resolveImportPathsBasedOnTsConfig.js
+++ b/src/no-relative-imports-when-same-folder/utils/tsConfig/resolveImportPathsBasedOnTsConfig.js
@@ -17,18 +17,20 @@ export default function resolveImportPathsBasedOnTsConfig({
 	const pathMappings = tsConfig.compilerOptions.paths;
 
 	if (!pathMappings) {
+		const { baseUrl } = tsConfig.compilerOptions;
+		// No paths and no baseUrl: nothing to resolve
+		if (!baseUrl) {
+			return [importPath];
+		}
 		// only baseUrl (e.g. `.` or `./src` is stated)
 		if (
-			!tsConfig.compilerOptions.baseUrl.length || // TODO: check if that is possible
-			tsConfig.compilerOptions.baseUrl === '.'
+			!baseUrl.length || // TODO: check if that is possible
+			baseUrl === '.'
 		) {
 			return importPath;
 		}
-		if (tsConfig.compilerOptions.baseUrl.startsWith('./')) {
-			const baseUrlAsAbsolute = tsConfig.compilerOptions.baseUrl.replace(
-				'./',
-				''
-			); // ./src -> src
+		if (baseUrl.startsWith('./')) {
+			const baseUrlAsAbsolute = baseUrl.replace('./', ''); // ./src -> src
 			return [pathModule.join(baseUrlAsAbsolute, importPath)];
 		}
 	}

--- a/src/no-relative-imports-when-same-folder/utils/tsConfig/resolveImportPathsBasedOnTsConfig.test.js
+++ b/src/no-relative-imports-when-same-folder/utils/tsConfig/resolveImportPathsBasedOnTsConfig.test.js
@@ -15,6 +15,42 @@ describe('resolveImportPathBasedOnTsConfig', () => {
 		expect(possiblePaths[0]).toBe('src/components/foo');
 	});
 
+	describe('when tsConfig only states `paths` (TypeScript 6 style, no baseUrl)', () => {
+		const tsConfig = {
+			compilerOptions: {
+				paths: {
+					'@library': ['./src/library/src/index.js'],
+					'@library/*': ['./src/library/src/*'],
+				},
+			},
+		};
+
+		it('handles aliases that do not state a wildcard', () => {
+			const possiblePaths = resolveImportPathsBasedOnTsConfig({
+				tsConfig,
+				importPath: '@library',
+			});
+			expect(possiblePaths).toEqual(['./src/library/src/index.js']);
+		});
+
+		it('handles aliases that state a wildcard', () => {
+			const possiblePaths = resolveImportPathsBasedOnTsConfig({
+				tsConfig,
+				importPath: '@library/foo',
+			});
+			// pathModule.join normalizes './' prefix
+			expect(possiblePaths).toEqual(['src/library/src/foo']);
+		});
+
+		it('returns the import path as-is when no alias matches', () => {
+			const possiblePaths = resolveImportPathsBasedOnTsConfig({
+				tsConfig,
+				importPath: 'some-package',
+			});
+			expect(possiblePaths).toEqual(['some-package']);
+		});
+	});
+
 	describe('when tsConfig also states paths', () => {
 		const tsConfig = {
 			compilerOptions: {


### PR DESCRIPTION
## Summary
This PR adds support for TypeScript 6's module resolution configuration style, which allows specifying `paths` without requiring a `baseUrl`. Previously, the linter only recognized module resolution when `baseUrl` was present.

## Key Changes
- **checkIfTsConfigAdaptsModuleResolution.js**: Updated to recognize `paths` configuration as a valid module resolution adapter, not just `baseUrl`
- **resolveImportPathsBasedOnTsConfig.js**: Added handling for the case where `paths` is configured but `baseUrl` is absent, returning the import path as-is when no alias matches
- **Test coverage**: Added comprehensive test suites for TypeScript 6 style configuration in both the main rule tests and the utility function tests

## Implementation Details
- When neither `baseUrl` nor `paths` are present, the import path is returned unchanged
- The existing logic for handling `baseUrl` is preserved for backward compatibility
- Path alias resolution with wildcards (e.g., `@library/*`) continues to work correctly with the new configuration style

https://claude.ai/code/session_01J57bKTrxwxx2z7G8eVxcuj